### PR TITLE
Fix support for rs384 and rs512.

### DIFF
--- a/Sources/base/JWT.swift
+++ b/Sources/base/JWT.swift
@@ -59,7 +59,7 @@ public struct JWT {
 
         self.header = try CompactJSONDecoder.shared.decode(JWTHeader.self, from: encodedHeader)
         self.payload = try CompactJSONDecoder.shared.decode(JWTPayload.self, from: encodedPayload)
-        try self.payload.checkExpiration()
+        try self.payload.checkExpiration(allowNil: true)
         try self.payload.checkIssueAt(allowNil: true)
         try self.payload.checkNotBefore(allowNil: true)
 

--- a/Sources/base/JWTPayload.swift
+++ b/Sources/base/JWTPayload.swift
@@ -117,8 +117,8 @@ public struct JWTPayload: Codable {
         try validateDate(key: DynamicKey.init(stringValue: JWTPayloadKeys.notBefore.rawValue), rightCompareResult: .orderedAscending, allowNil: allowNil)
     }
 
-    public func checkExpiration() throws {
-        try validateDate(key: DynamicKey.init(stringValue: JWTPayloadKeys.expiration.rawValue), rightCompareResult: .orderedDescending, allowNil: false)
+    public func checkExpiration(allowNil: Bool) throws {
+        try validateDate(key: DynamicKey.init(stringValue: JWTPayloadKeys.expiration.rawValue), rightCompareResult: .orderedDescending, allowNil: allowNil)
     }
 
     public func checkIssueAt(allowNil: Bool) throws {

--- a/SwiftyJWTTests/JWTPayloadTests.swift
+++ b/SwiftyJWTTests/JWTPayloadTests.swift
@@ -33,8 +33,9 @@ class JWTPayloadTests: XCTestCase {
         let payload = try? CompactJSONDecoder.shared.decode(JWTPayload.self, from: encodedPayload)
         XCTAssertNotNil(payload)
 
+        // expiration is not nil, so it always is expired
         XCTAssertThrowsError(try payload?.checkExpiration(allowNil: false))
-        XCTAssertNoThrow(try payload?.checkExpiration(allowNil: true))
+        XCTAssertThrowsError(try payload?.checkExpiration(allowNil: true))
 
         XCTAssertThrowsError(try payload?.checkIssueAt(allowNil: false))
         XCTAssertNoThrow(try payload?.checkIssueAt(allowNil: true))

--- a/SwiftyJWTTests/JWTPayloadTests.swift
+++ b/SwiftyJWTTests/JWTPayloadTests.swift
@@ -33,7 +33,8 @@ class JWTPayloadTests: XCTestCase {
         let payload = try? CompactJSONDecoder.shared.decode(JWTPayload.self, from: encodedPayload)
         XCTAssertNotNil(payload)
 
-        XCTAssertThrowsError(try payload?.checkExpiration())
+        XCTAssertThrowsError(try payload?.checkExpiration(allowNil: false))
+        XCTAssertNoThrow(try payload?.checkExpiration(allowNil: true))
 
         XCTAssertThrowsError(try payload?.checkIssueAt(allowNil: false))
         XCTAssertNoThrow(try payload?.checkIssueAt(allowNil: true))


### PR DESCRIPTION
There was a bug in the code so that it used .sha256 for all RSA digest work. I've modified the code to make the digest type a parameter, so that the other options will also work. 

I also added support for nil expiration dates, which aren't a good idea, but my team needs.

I hope it's OK that I am suggesting these changes! Please let me know if you would prefer I report this another way. 