### PR TITLE
Fix support for rs384 and rs512, without changing expiration handling.

### DIFF
--- a/Sources/base/JWT.swift
+++ b/Sources/base/JWT.swift
@@ -59,7 +59,7 @@ public struct JWT {
 
         self.header = try CompactJSONDecoder.shared.decode(JWTHeader.self, from: encodedHeader)
         self.payload = try CompactJSONDecoder.shared.decode(JWTPayload.self, from: encodedPayload)
-        try self.payload.checkExpiration(allowNil: true)
+        try self.payload.checkExpiration(allowNil: false)
         try self.payload.checkIssueAt(allowNil: true)
         try self.payload.checkNotBefore(allowNil: true)
 

--- a/Sources/base/JWT.swift
+++ b/Sources/base/JWT.swift
@@ -59,7 +59,7 @@ public struct JWT {
 
         self.header = try CompactJSONDecoder.shared.decode(JWTHeader.self, from: encodedHeader)
         self.payload = try CompactJSONDecoder.shared.decode(JWTPayload.self, from: encodedPayload)
-        try self.payload.checkExpiration()
+        try self.payload.checkExpiration(allowNil: true)
         try self.payload.checkIssueAt(allowNil: true)
         try self.payload.checkNotBefore(allowNil: true)
 

--- a/Sources/base/JWTPayload.swift
+++ b/Sources/base/JWTPayload.swift
@@ -117,8 +117,8 @@ public struct JWTPayload: Codable {
         try validateDate(key: DynamicKey.init(stringValue: JWTPayloadKeys.notBefore.rawValue), rightCompareResult: .orderedAscending, allowNil: allowNil)
     }
 
-    public func checkExpiration() throws {
-        try validateDate(key: DynamicKey.init(stringValue: JWTPayloadKeys.expiration.rawValue), rightCompareResult: .orderedDescending, allowNil: false)
+    public func checkExpiration(allowNil: Bool) throws {
+        try validateDate(key: DynamicKey.init(stringValue: JWTPayloadKeys.expiration.rawValue), rightCompareResult: .orderedDescending, allowNil: allowNil)
     }
 
     public func checkIssueAt(allowNil: Bool) throws {

--- a/SwiftyJWT.podspec
+++ b/SwiftyJWT.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "SwiftyJWT"
-  s.version      = "0.0.2"
+  s.version      = "0.0.3"
   s.summary      = "A library to generate JWT with Swift"
   s.homepage     = "https://github.com/Wstunes/SwiftyJWT"
   s.license      = { :type => "MIT", :file => "LICENSE" }

--- a/SwiftyJWTTests/JWTPayloadTests.swift
+++ b/SwiftyJWTTests/JWTPayloadTests.swift
@@ -33,7 +33,9 @@ class JWTPayloadTests: XCTestCase {
         let payload = try? CompactJSONDecoder.shared.decode(JWTPayload.self, from: encodedPayload)
         XCTAssertNotNil(payload)
 
-        XCTAssertThrowsError(try payload?.checkExpiration())
+        // expiration is not nil, so it always is expired
+        XCTAssertThrowsError(try payload?.checkExpiration(allowNil: false))
+        XCTAssertThrowsError(try payload?.checkExpiration(allowNil: true))
 
         XCTAssertThrowsError(try payload?.checkIssueAt(allowNil: false))
         XCTAssertNoThrow(try payload?.checkIssueAt(allowNil: true))


### PR DESCRIPTION
I've left in the option to make nil expiration dates possible, but made JWT.init require them. This correctly maintains the previous behavior.